### PR TITLE
Dev

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: TreatmentPatterns
 Type: Package
 Title: Analyzes Real-World Treatment Patterns of a Study Population of Interest
-Version: 2.6.7
+Version: 2.6.8
 Authors@R: 
     c(person("Aniek", "Markus", , role = c("aut"), comment = c(ORCID = "0000-0001-5779-4794")),
       person("Maarten", "van Kessel", email = "m.l.vankessel@erasmusmc.nl", role = c("cre"), comment = c(ORCID = "0009-0006-8832-6030")))

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+# TreatmentPatterns 2.6.8
+---------
+* Updated some tests to work with later versions of omopgenerics.
+* Fixed issue with where combinations sometimes got miss-classified.
+* Fixed issue when event starts and ends on end-date of target.
+* Fixed issue when collapsing events when there is also a combination, when `filterTreatments = "All"`.
+* Added check in tests to only run if packages are availible. (noSuggests, M1).
+
 # TreatmentPatterns 2.6.7
 ---------
 * Updated URLs in description

--- a/R/createSankeyDiagram.R
+++ b/R/createSankeyDiagram.R
@@ -16,28 +16,17 @@ splitPathItems <- function(treatmentPathways) {
 }
 
 createLinks <- function(data) {
-  result1 <- data %>%
-    mutate(
-      source = paste0("1.", .data$path1),
-      target = paste0("2.", .data$path2)
-    ) %>%
-    select("source", "target", "freq")
-  
-  
-  if (suppressWarnings(!is.null(data$path3))) {
-    result2 <- data %>%
-      mutate(
-        source = paste0("2.", .data$path2),
-        target = paste0("3.", .data$path3)
-      ) %>%
-      select("source", "target", "freq")
-    
-    links <- dplyr::bind_rows(
-      result1, result2
-    )
-  } else {
-    links <- result1
-  }
+  links <- lapply(seq_len(ncol(data) - 2), function(i) {
+    df <- data[, c(i, i + 1, ncol(data))]
+    names(df) <- c("source", "target", "freq")
+    df <- df %>%
+      dplyr::mutate(
+        source = sprintf("%s.%s", i, .data$source),
+        target = sprintf("%s.%s", i + 1, .data$target)
+      )
+    return(df)
+  }) |>
+    dplyr::bind_rows()
   
   links <- links %>%
     dplyr::mutate(value = round(freq / sum(freq) * 100, 2)) %>%

--- a/man/CharacterizationPlots.Rd
+++ b/man/CharacterizationPlots.Rd
@@ -7,7 +7,7 @@
 Class to handle the characterization plots.
 }
 \section{Super class}{
-\code{TreatmentPatterns::ShinyModule} -> \code{CharacterizationPlots}
+\code{\link[TreatmentPatterns:ShinyModule]{TreatmentPatterns::ShinyModule}} -> \code{CharacterizationPlots}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/man/InputHandler.Rd
+++ b/man/InputHandler.Rd
@@ -8,7 +8,7 @@ Class to handle input from the user. Supports direct paths or input fields
 through \code{setDataPath()}.\cr\cr
 }
 \section{Super class}{
-\code{TreatmentPatterns::ShinyModule} -> \code{InputHandler}
+\code{\link[TreatmentPatterns:ShinyModule]{TreatmentPatterns::ShinyModule}} -> \code{InputHandler}
 }
 \section{Active bindings}{
 \if{html}{\out{<div class="r6-active-bindings">}}

--- a/man/SankeyDiagram.Rd
+++ b/man/SankeyDiagram.Rd
@@ -7,7 +7,7 @@
 Class to handle the Sankey diagram of TreatmentPatterns.
 }
 \section{Super classes}{
-\code{TreatmentPatterns::ShinyModule} -> \code{TreatmentPatterns::InteracitvePlot} -> \code{SankeyDiagram}
+\code{\link[TreatmentPatterns:ShinyModule]{TreatmentPatterns::ShinyModule}} -> \code{TreatmentPatterns::InteracitvePlot} -> \code{SankeyDiagram}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/man/SunburstPlot.Rd
+++ b/man/SunburstPlot.Rd
@@ -7,7 +7,7 @@
 Class to handle the Sunburst plot of TreatmentPatterns.
 }
 \section{Super classes}{
-\code{TreatmentPatterns::ShinyModule} -> \code{TreatmentPatterns::InteracitvePlot} -> \code{SunburstPlot}
+\code{\link[TreatmentPatterns:ShinyModule]{TreatmentPatterns::ShinyModule}} -> \code{TreatmentPatterns::InteracitvePlot} -> \code{SunburstPlot}
 }
 \section{Methods}{
 \subsection{Public methods}{

--- a/tests/testthat/helper-ableToRun.R
+++ b/tests/testthat/helper-ableToRun.R
@@ -1,7 +1,24 @@
 ableToRun <- function() {
-  all(
-    require("CirceR", character.only = TRUE, quietly = TRUE),
-    require("Eunomia", character.only = TRUE, quietly = TRUE),
-    require("CohortGenerator", character.only = TRUE, quietly = TRUE)
+  list(
+    CDMC = all(
+      require("CirceR", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("CDMConnector", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("DBI", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("duckdb", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE)
+    ),
+
+    CG = all(
+      require("CirceR", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("CohortGenerator", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("DatabaseConnector", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("SqlRender", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("Eunomia", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE)
+    ),
+
+    plotting = all(
+      require("ggplot2", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("webshot2", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE),
+      require("plotly", character.only = TRUE, quietly = TRUE, warn.conflicts = FALSE)
+    )
   )
 }

--- a/tests/testthat/helper-generateCohortTableCDMC.R
+++ b/tests/testthat/helper-generateCohortTableCDMC.R
@@ -1,39 +1,43 @@
 generateCohortTableCDMC <- function() {
-  cohortTableName <- "cohort_table"
-  
-  con <- DBI::dbConnect(
-    duckdb::duckdb(),
-    dbdir = CDMConnector::eunomia_dir()
-  )
-  
-  cdm <- CDMConnector::cdmFromCon(
-    con = con,
-    cdmSchema = "main",
-    writeSchema = "main"
-  )
-  
-  ## Read in cohort set ----
-  cohortsSet <- CDMConnector::readCohortSet(
-    path = system.file(package = "TreatmentPatterns", "exampleCohorts")
-  )
-  
-  ## Generate cohot set ----
-  cdm <- CDMConnector::generateCohortSet(
-    cdm = cdm,
-    cohortSet = cohortsSet,
-    name = cohortTableName,
-    computeAttrition = FALSE
-  )
-  
-  cohorts <- data.frame(
-    cohortId = cohortsSet$cohort_definition_id,
-    cohortName = cohortsSet$cohort_name,
-    type = c("event", "event", "event", "event", "exit", "event", "event", "target")
-  )
-  return(list(
-    cdm = cdm,
-    cohorts = cohorts,
-    cohortTableName = cohortTableName,
-    con = con
-  ))
+  if (ableToRun()$CDMC) {
+    cohortTableName <- "cohort_table"
+    
+    con <- DBI::dbConnect(
+      duckdb::duckdb(),
+      dbdir = CDMConnector::eunomia_dir()
+    )
+    
+    cdm <- CDMConnector::cdmFromCon(
+      con = con,
+      cdmSchema = "main",
+      writeSchema = "main"
+    )
+    
+    ## Read in cohort set ----
+    cohortsSet <- CDMConnector::readCohortSet(
+      path = system.file(package = "TreatmentPatterns", "exampleCohorts")
+    )
+    
+    ## Generate cohot set ----
+    cdm <- CDMConnector::generateCohortSet(
+      cdm = cdm,
+      cohortSet = cohortsSet,
+      name = cohortTableName,
+      computeAttrition = FALSE
+    )
+    
+    cohorts <- data.frame(
+      cohortId = cohortsSet$cohort_definition_id,
+      cohortName = cohortsSet$cohort_name,
+      type = c("event", "event", "event", "event", "exit", "event", "event", "target")
+    )
+    return(list(
+      cdm = cdm,
+      cohorts = cohorts,
+      cohortTableName = cohortTableName,
+      con = con
+    ))
+  } else {
+    return(NULL)
+  }
 }

--- a/tests/testthat/helper-generateCohortTableCG.R
+++ b/tests/testthat/helper-generateCohortTableCG.R
@@ -1,78 +1,82 @@
 generateCohortTableCG <- function() {
-  connectionDetails <- Eunomia::getEunomiaConnectionDetails()
-  cohortTableName <- "cohort_table"
-  resultSchema <- "main"
-  cdmSchema <- "main"
-  
-  cohortsToCreate <- CohortGenerator::createEmptyCohortDefinitionSet()
-  
-  cohortJsonFiles <- list.files(
-    system.file(
-      package = "TreatmentPatterns",
-      "exampleCohorts"),
-    full.names = TRUE)
-  
-  for (i in seq_len(length(cohortJsonFiles))) {
-    cohortJsonFileName <- cohortJsonFiles[i]
-    cohortName <- tools::file_path_sans_ext(basename(cohortJsonFileName))
-    cohortJson <- readChar(cohortJsonFileName, file.info(
-      cohortJsonFileName)$size)
+  if (ableToRun()$CG) {
+    connectionDetails <- Eunomia::getEunomiaConnectionDetails()
+    cohortTableName <- "cohort_table"
+    resultSchema <- "main"
+    cdmSchema <- "main"
     
-    cohortExpression <- CirceR::cohortExpressionFromJson(cohortJson)
+    cohortsToCreate <- CohortGenerator::createEmptyCohortDefinitionSet()
     
-    cohortSql <- CirceR::buildCohortQuery(
-      cohortExpression,
-      options = CirceR::createGenerateOptions(generateStats = FALSE))
-    cohortsToCreate <- rbind(
-      cohortsToCreate,
-      data.frame(
-        cohortId = i,
-        cohortName = cohortName,
-        sql = cohortSql,
-        stringsAsFactors = FALSE))
+    cohortJsonFiles <- list.files(
+      system.file(
+        package = "TreatmentPatterns",
+        "exampleCohorts"),
+      full.names = TRUE)
+    
+    for (i in seq_len(length(cohortJsonFiles))) {
+      cohortJsonFileName <- cohortJsonFiles[i]
+      cohortName <- tools::file_path_sans_ext(basename(cohortJsonFileName))
+      cohortJson <- readChar(cohortJsonFileName, file.info(
+        cohortJsonFileName)$size)
+      
+      cohortExpression <- CirceR::cohortExpressionFromJson(cohortJson)
+      
+      cohortSql <- CirceR::buildCohortQuery(
+        cohortExpression,
+        options = CirceR::createGenerateOptions(generateStats = FALSE))
+      cohortsToCreate <- rbind(
+        cohortsToCreate,
+        data.frame(
+          cohortId = i,
+          cohortName = cohortName,
+          sql = cohortSql,
+          stringsAsFactors = FALSE))
+    }
+    
+    cohortTableNames <- CohortGenerator::getCohortTableNames(
+      cohortTable = cohortTableName)
+    
+    CohortGenerator::createCohortTables(
+      connectionDetails = connectionDetails,
+      cohortDatabaseSchema = resultSchema,
+      cohortTableNames = cohortTableNames)
+    
+    # Generate the cohorts
+    cohortsGenerated <- CohortGenerator::generateCohortSet(
+      connectionDetails = connectionDetails,
+      cdmDatabaseSchema = cdmSchema,
+      cohortDatabaseSchema = resultSchema,
+      cohortTableNames = cohortTableNames,
+      cohortDefinitionSet = cohortsToCreate)
+    
+    # Select Viral Sinusitis Cohort
+    targetCohorts <- cohortsGenerated %>%
+      dplyr::filter(cohortName == "ViralSinusitis") %>%
+      dplyr::select(cohortId, cohortName)
+    
+    # Select everything BUT Viral Sinusitis cohorts
+    eventCohorts <- cohortsGenerated %>%
+      dplyr::filter(cohortName != "ViralSinusitis" & cohortName != "Death") %>%
+      dplyr::select(cohortId, cohortName)
+    
+    exitCohorts <- cohortsGenerated %>%
+      dplyr::filter(cohortName == "Death") %>%
+      dplyr::select(cohortId, cohortName)
+    
+    cohorts <- dplyr::bind_rows(
+      targetCohorts %>% dplyr::mutate(type = "target"),
+      eventCohorts %>% dplyr::mutate(type = "event"),
+      exitCohorts %>% dplyr::mutate(type = "exit")
+    )
+    
+    return(list(
+      cohorts = cohorts,
+      connectionDetails = connectionDetails,
+      cohortTableName = cohortTableName,
+      resultSchema = resultSchema,
+      cdmSchema = cdmSchema
+    ))
+  } else {
+    return(NULL)
   }
-  
-  cohortTableNames <- CohortGenerator::getCohortTableNames(
-    cohortTable = cohortTableName)
-  
-  CohortGenerator::createCohortTables(
-    connectionDetails = connectionDetails,
-    cohortDatabaseSchema = resultSchema,
-    cohortTableNames = cohortTableNames)
-  
-  # Generate the cohorts
-  cohortsGenerated <- CohortGenerator::generateCohortSet(
-    connectionDetails = connectionDetails,
-    cdmDatabaseSchema = cdmSchema,
-    cohortDatabaseSchema = resultSchema,
-    cohortTableNames = cohortTableNames,
-    cohortDefinitionSet = cohortsToCreate)
-  
-  # Select Viral Sinusitis Cohort
-  targetCohorts <- cohortsGenerated %>%
-    dplyr::filter(cohortName == "ViralSinusitis") %>%
-    dplyr::select(cohortId, cohortName)
-  
-  # Select everything BUT Viral Sinusitis cohorts
-  eventCohorts <- cohortsGenerated %>%
-    dplyr::filter(cohortName != "ViralSinusitis" & cohortName != "Death") %>%
-    dplyr::select(cohortId, cohortName)
-  
-  exitCohorts <- cohortsGenerated %>%
-    dplyr::filter(cohortName == "Death") %>%
-    dplyr::select(cohortId, cohortName)
-  
-  cohorts <- dplyr::bind_rows(
-    targetCohorts %>% dplyr::mutate(type = "target"),
-    eventCohorts %>% dplyr::mutate(type = "event"),
-    exitCohorts %>% dplyr::mutate(type = "exit")
-  )
-  
-  return(list(
-    cohorts = cohorts,
-    connectionDetails = connectionDetails,
-    cohortTableName = cohortTableName,
-    resultSchema = resultSchema,
-    cdmSchema = cdmSchema
-  ))
 }

--- a/tests/testthat/test-CDMInterface.R
+++ b/tests/testthat/test-CDMInterface.R
@@ -47,18 +47,34 @@ test_that("fetchCohortTable", {
   
   # check n > 1 treatments
   expect_identical(
-    aCG$cohort_table %>% group_by(.data$subject_id) %>%
-      summarize(n = n()) %>% filter(n > 1) %>% collect(),
-    aCDMC$cohort_table %>% group_by(.data$subject_id) %>%
-      summarize(n = n()) %>% filter(n > 1) %>% collect()
+    aCG$cohort_table %>%
+      group_by(.data$subject_id) %>%
+      summarize(n = n()) %>%
+      filter(n > 1) %>%
+      collect() %>%
+      mutate(subject_id = as.numeric(subject_id)),
+    aCDMC$cohort_table %>%
+      group_by(.data$subject_id) %>%
+      summarize(n = n()) %>%
+      filter(n > 1) %>%
+      collect() %>%
+      mutate(subject_id = as.numeric(subject_id))
   )
-  
+
   # check n == 1 treatments
   expect_identical(
-    aCG$cohort_table %>% group_by(.data$subject_id) %>%
-      summarize(n = n()) %>% filter(n == 1) %>% collect(),
-    aCDMC$cohort_table %>% group_by(.data$subject_id) %>%
-      summarize(n = n()) %>% filter(n == 1) %>% collect()
+    aCG$cohort_table %>%
+      group_by(.data$subject_id) %>%
+      summarize(n = n()) %>%
+      filter(n == 1) %>%
+      collect() %>%
+      mutate(subject_id = as.numeric(subject_id)),
+    aCDMC$cohort_table %>%
+      group_by(.data$subject_id) %>%
+      summarize(n = n()) %>%
+      filter(n == 1) %>%
+      collect() %>%
+      mutate(subject_id = as.numeric(subject_id))
   )
   
   dbcInterface$disconnect()

--- a/tests/testthat/test-CDMInterfaceDBC.R
+++ b/tests/testthat/test-CDMInterfaceDBC.R
@@ -1,11 +1,10 @@
 library(testthat)
 library(TreatmentPatterns)
 library(dplyr)
-library(Eunomia)
-library(DatabaseConnector)
 
 test_that("Method: new", {
   skip("Eunomia [2.0.0] bug")
+  skip_if_not(ableToRun()$CG)
   connectionDetails <- Eunomia::getEunomiaConnectionDetails()
 
   cdmInterface <- TreatmentPatterns:::CDMInterface$new(
@@ -23,6 +22,7 @@ test_that("Method: new", {
 
 test_that("Method: fetchMetadata", {
   skip("Eunomia [2.0.0] bug")
+  skip_if_not(ableToRun()$CG)
   connectionDetails <- Eunomia::getEunomiaConnectionDetails()
   
   cdmInterface <- TreatmentPatterns:::CDMInterface$new(
@@ -51,6 +51,7 @@ test_that("Method: fetchMetadata", {
 
 test_that("Method: fetchCohortTable", {
   skip("Eunomia [2.0.0] bug")
+  skip_if_not(ableToRun()$CG)
   globals <- generateCohortTableCG()
   
   andromeda <- Andromeda::andromeda()
@@ -77,6 +78,7 @@ test_that("Method: fetchCohortTable", {
 
 test_that("fetchCohortTable: empty", {
   skip("Eunomia [2.0.0] bug")
+  skip_if_not(ableToRun()$CG)
   globals <- generateCohortTableCG()
   
   andromeda <- Andromeda::andromeda()
@@ -113,6 +115,7 @@ test_that("fetchCohortTable: empty", {
 
 test_that("Method: disconnect", {
   skip("Eunomia [2.0.0] bug")
+  skip_if_not(ableToRun()$CG)
   connectionDetails <- Eunomia::getEunomiaConnectionDetails()
   
   cdmInterface <- TreatmentPatterns:::CDMInterface$new(

--- a/tests/testthat/test-CharacterizationPlots.R
+++ b/tests/testthat/test-CharacterizationPlots.R
@@ -4,11 +4,13 @@ library(shiny)
 library(TreatmentPatterns)
 
 test_that("CharacterizationPlots", {
+  skip_if_not(ableToRun()$plotting)
   characterizationPlots <- CharacterizationPlots$new("app")
   expect_true(is.R6(characterizationPlots))
 })
 
 test_that("UI", {
+  skip_if_not(ableToRun()$plotting)
   characterizationPlots <- CharacterizationPlots$new("app")
   
   expect_s3_class(characterizationPlots$uiBody(), "shiny.tag")
@@ -17,6 +19,7 @@ test_that("UI", {
 
 
 test_that("server", {
+  skip_if_not(ableToRun()$plotting)
   moduleInteractivePlots <- function(id, inputHandler, characterizationPlots) {
     moduleServer(id, function(input, output, session) {
       inputHandler$setDataPath(input = input, path = NULL)

--- a/tests/testthat/test-InputHandler.R
+++ b/tests/testthat/test-InputHandler.R
@@ -3,6 +3,7 @@ library(testthat)
 library(R6)
 
 test_that("InputHandler", {
+  skip_if_not(ableToRun()$plotting)
   ## new() / initialize() ----
   inputHandler <- InputHandler$new("app")
   expect_true(is.R6(inputHandler))
@@ -16,6 +17,7 @@ test_that("InputHandler", {
 })
 
 test_that("UI", {
+  skip_if_not(ableToRun()$plotting)
   inputHandler <- InputHandler$new("app")
   expect_s3_class(inputHandler$uiMenu(), "shiny.tag")
   expect_s3_class(inputHandler$uiBody(), "shiny.tag")
@@ -23,6 +25,7 @@ test_that("UI", {
 })
 
 test_that("InputHandler: setDataPath()", {
+  skip_if_not(ableToRun()$plotting)
   moduleInputHandler <- function(id, inputHandler) {
     shiny::moduleServer(id, function(input, output, session) {})
   }
@@ -58,6 +61,7 @@ test_that("InputHandler: setDataPath()", {
 })
 
 test_that("InputHandler: server()", {
+  skip_if_not(ableToRun()$plotting)
   moduleInputHandler <- function(id, inputHandler) {
     shiny::moduleServer(id, function(input, output, session) {
       inputHandler$setDataPath(input = input, path = NULL)
@@ -93,6 +97,7 @@ test_that("InputHandler: server()", {
 })
 
 test_that("server: dir and zip-file", {
+  skip_if_not(ableToRun()$plotting)
   moduleInteractivePlots <- function(id, inputHandler, sunburst, sankey) {
     moduleServer(id, function(input, output, session) {
       inputHandler$setDataPath(input = input, path = NULL)

--- a/tests/testthat/test-InteractivePlots.R
+++ b/tests/testthat/test-InteractivePlots.R
@@ -5,6 +5,7 @@ library(dplyr)
 library(TreatmentPatterns)
 
 test_that("InteracivePlots", {
+  skip_if_not(ableToRun()$plotting)
   sunburst <- SunburstPlot$new("app")
   sankey <- SankeyDiagram$new("app")
   expect_true(is.R6(sunburst))
@@ -12,6 +13,7 @@ test_that("InteracivePlots", {
 })
 
 test_that("UI", {
+  skip_if_not(ableToRun()$plotting)
   sunburst <- SunburstPlot$new("app")
   sankey <- SankeyDiagram$new("app")
 
@@ -23,6 +25,7 @@ test_that("UI", {
 })
 
 test_that("server: inputs", {
+  skip_if_not(ableToRun()$plotting)
   moduleInteractivePlots <- function(id, inputHandler, sunburst, sankey) {
     moduleServer(id, function(input, output, session) {
       inputHandler$setDataPath(input = input, path = NULL)

--- a/tests/testthat/test-ShinyApp.R
+++ b/tests/testthat/test-ShinyApp.R
@@ -3,6 +3,7 @@ library(shiny)
 library(R6)
 
 test_that("ShinyApp", {
+  skip_if_not(ableToRun()$plotting)
   app <- TreatmentPatterns:::ShinyApp$new("app")
   
   # Fields

--- a/tests/testthat/test-computePathways.R
+++ b/tests/testthat/test-computePathways.R
@@ -3,11 +3,10 @@ library(testthat)
 library(TreatmentPatterns)
 library(dplyr)
 library(stringr)
-library(CDMConnector)
 
 test_that("computePathways DatabaseConnector", {
   skip("Eunomia [2.0.0] bug")
-
+  skip_if_not(ableToRun()$CG)
   globals <- generateCohortTableCG()
   
   expect_message(
@@ -20,56 +19,39 @@ test_that("computePathways DatabaseConnector", {
           cdmSchema = "main",
           resultSchema = "main"
         ),
-        "After maxPathLength: 554"
+        "After maxPathLength: 553"
       ),
-      "After combinationWindow: 555"
+      "After combinationWindow: 554"
     ),
-    "Original number of rows: 8352"
+    "Original number of rows: 8366"
   )
 })
 
 test_that("computePathways CDMConnector", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
   
   expect_message(
     expect_message(
       expect_message(
         computePathways(
-          cdm = globals$cdm,
           cohorts = globals$cohorts,
-          cohortTableName = globals$cohortTableName
+          cdm = globals$cdm,
+          globals$cohortTableName
         ),
-        "After maxPathLength: 554"
+        "After maxPathLength: 553"
       ),
-      "After combinationWindow: 555"
+      "After combinationWindow: 554"
     ),
-    "Original number of rows: 8352"
+    "Original number of rows: 8366"
   )
   
   DBI::dbDisconnect(globals$con, shutdown = TRUE)
 })
 
 test_that("nrow exitCohorts > 0", {
-  globals <- generateCohortTableCDMC()
-  
-  cohorts <- globals$cohorts %>%
-    mutate(type = case_when(
-      .data$cohortName == "Acetaminophen" ~ "exit",
-      .default = .data$type
-    ))
-  
-  expect_message(
-    computePathways(
-      cdm = globals$cdm,
-      cohorts = cohorts,
-      cohortTableName = globals$cohortTableName
-    ),
-    "After maxPathLength: 554"
-  )
-})
-
-test_that("nrow exitCohorts > 0", {
   skip("Eunomia [2.0.0] bug")
+  skip_if_not(ableToRun()$CG)
   globals <- generateCohortTableCG()
   
   cohorts <- globals$cohorts %>%
@@ -92,6 +74,7 @@ test_that("nrow exitCohorts > 0", {
 
 # Parameter sweep ----
 test_that("includeTreatments", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
 
   andromeda_startDate <- computePathways(
@@ -135,8 +118,9 @@ test_that("includeTreatments", {
 })
 
 test_that("periodPriorToIndex", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
-  
+
   expect_error(
     computePathways(
       cohorts = globals$cohorts,
@@ -149,8 +133,9 @@ test_that("periodPriorToIndex", {
 })
 
 test_that("minEraDuration", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
-  
+
   expect_error(
     computePathways(
       cohorts = globals$cohorts,
@@ -163,8 +148,9 @@ test_that("minEraDuration", {
 })
 
 test_that("splitEventCohorts", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
-  
+
   andromeda_empty <- computePathways(
     cohorts = globals$cohorts,
     cohortTableName = globals$cohortTableName,
@@ -200,8 +186,9 @@ test_that("splitEventCohorts", {
 })
 
 test_that("splitTime", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
-  
+
   expect_error(
     computePathways(
       cohorts = globals$cohorts,
@@ -214,6 +201,7 @@ test_that("splitTime", {
 })
 
 test_that("eraCollapseSize", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
 
   andromeda_0 <- computePathways(
@@ -245,8 +233,9 @@ test_that("eraCollapseSize", {
 })
 
 test_that("combinationWindow", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
-  
+
   expect_error(
     suppressWarnings(
       computePathways(
@@ -261,6 +250,7 @@ test_that("combinationWindow", {
 })
 
 test_that("minPostCombinationDuration: 30", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -372,6 +362,7 @@ test_that("minPostCombinationDuration: 30", {
 })
 
 test_that("filterTreatments", {
+  skip_if_not(ableToRun()$CDMC)
   globals <- generateCohortTableCDMC()
 
   expect_error(
@@ -429,11 +420,13 @@ test_that("filterTreatments", {
     class(allTH$eventCohortId)
   )
 
-  expect_identical(
-    "numeric",
-    class(firstTH$personId),
-    class(changesTH$personId),
-    class(allTH$personId)
+  expect_contains(
+    expected = c(
+      class(firstTH$personId),
+      class(changesTH$personId),
+      class(allTH$personId)
+    ),
+    object = c("integer", "numeric")
   )
 
   expect_identical(
@@ -507,9 +500,9 @@ test_that("filterTreatments", {
   expect_false(any(is.null(changesTH)))
   expect_false(any(is.null(allTH)))
   
-  expect_true(nrow(firstTH) == 554)
-  expect_true(nrow(changesTH) == 555)
-  expect_true(nrow(allTH) == 555)
+  expect_true(nrow(firstTH) == 553)
+  expect_true(nrow(changesTH) == 554)
+  expect_true(nrow(allTH) == 554)
 
   expect_true(Andromeda::isAndromeda(first))
   expect_true(Andromeda::isAndromeda(changes))
@@ -518,4 +511,110 @@ test_that("filterTreatments", {
   Andromeda::close(first)
   Andromeda::close(changes)
   Andromeda::close(all)
+})
+
+test_that("FRFS combination", {
+  skip_if_not(ableToRun()$CDMC)
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
+  
+  cohorts <- data.frame(
+    cohortId = c(1, 2, 3),
+    cohortName = c("X", "A", "B"),
+    type = c("target", "event", "event")
+  )
+  
+  cohort_table <- dplyr::tribble(
+    ~cohort_definition_id, ~subject_id, ~cohort_start_date, ~cohort_end_date,
+    
+    1, 5, as.Date("2017-08-03"), as.Date("2018-08-02"),
+    3, 5, as.Date("2017-11-26"), as.Date("2018-04-10"),
+    2, 5, as.Date("2018-02-26"), as.Date("2018-04-24"),
+    
+    1, 7, as.Date("2015-10-20"), as.Date("2018-06-28"),
+    2, 7, as.Date("2017-12-04"), as.Date("2018-04-30")
+  )
+  
+  copy_to(con, cohort_table, overwrite = TRUE)
+  
+  cdm <- cdmFromCon(con, cdmSchema = "main", writeSchema = "main", cohortTables = "cohort_table")
+  
+  andromeda <- computePathways(
+    cohorts = cohorts,
+    cohortTableName = 'cohort_table',
+    cdm = cdm,
+    tempEmulationSchema = NULL,
+    includeTreatments = "startDate",
+    periodPriorToIndex = 0,
+    minEraDuration = 30,
+    eraCollapseSize = 30,
+    combinationWindow = 30,
+    minPostCombinationDuration = 30,
+    filterTreatments = "All",
+    maxPathLength = 5)
+  
+  nFRFS <- andromeda$addRowsFRFS_1 %>%
+    dplyr::collect() %>%
+    nrow()
+
+  nLRFS <- andromeda$addRowsLRFS_1 %>%
+    dplyr::collect() %>%
+    nrow()
+
+  expect_equal(nFRFS, 1)
+  expect_equal(nLRFS, 0)
+
+  DBI::dbDisconnect(con)
+})
+
+test_that("LRFS combination", {
+  skip_if_not(ableToRun()$CDMC)
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
+  
+  cohorts <- data.frame(
+    cohortId = c(1, 2, 3),
+    cohortName = c("X", "A", "B"),
+    type = c("target", "event", "event")
+  )
+  
+  cohort_table <- dplyr::tribble(
+    ~cohort_definition_id, ~subject_id, ~cohort_start_date, ~cohort_end_date,
+    
+    1, 5, as.Date("2017-08-03"), as.Date("2018-08-02"),
+    3, 5, as.Date("2017-11-26"), as.Date("2018-04-10"),
+    2, 5, as.Date("2018-01-26"), as.Date("2018-03-24"),
+    
+    1, 7, as.Date("2015-10-20"), as.Date("2018-06-28"),
+    2, 7, as.Date("2017-12-04"), as.Date("2018-04-30")
+  )
+  
+  copy_to(con, cohort_table, overwrite = TRUE)
+  
+  cdm <- cdmFromCon(con, cdmSchema = "main", writeSchema = "main", cohortTables = "cohort_table")
+  
+  andromeda <- computePathways(
+    cohorts = cohorts,
+    cohortTableName = 'cohort_table',
+    cdm = cdm,
+    tempEmulationSchema = NULL,
+    includeTreatments = "startDate",
+    periodPriorToIndex = 0,
+    minEraDuration = 30,
+    eraCollapseSize = 30,
+    combinationWindow = 30,
+    minPostCombinationDuration = 30,
+    filterTreatments = "All",
+    maxPathLength = 5)
+  
+  nFRFS <- andromeda$addRowsFRFS_1 %>%
+    dplyr::collect() %>%
+    nrow()
+  
+  nLRFS <- andromeda$addRowsLRFS_1 %>%
+    dplyr::collect() %>%
+    nrow()
+  
+  expect_equal(nFRFS, 0)
+  expect_equal(nLRFS, 1)
+  
+  DBI::dbDisconnect(con)
 })

--- a/tests/testthat/test-launchResultsExplorer.R
+++ b/tests/testthat/test-launchResultsExplorer.R
@@ -2,6 +2,7 @@ library(testthat)
 library(TreatmentPatterns)
 
 test_that("launchResultsExplorer", {
+  skip_if_not(ableToRun()$plotting)
   app <- launchResultsExplorer()
   expect_s3_class(app, "shiny.appobj")
   

--- a/tests/testthat/test-pathwaysLogical.R
+++ b/tests/testthat/test-pathwaysLogical.R
@@ -1,9 +1,9 @@
 library(testthat)
 library(TreatmentPatterns)
 library(dplyr)
-library(CDMConnector)
 
 test_that("A", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -54,6 +54,7 @@ test_that("A", {
 })
 
 test_that("A-B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -106,6 +107,7 @@ test_that("A-B", {
 
 
 test_that("A-B-C", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -158,6 +160,7 @@ test_that("A-B-C", {
 })
 
 test_that("A-B+C", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -210,6 +213,7 @@ test_that("A-B+C", {
 })
 
 test_that("A+B-C", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -262,6 +266,7 @@ test_that("A+B-C", {
 })
 
 test_that("A-A+B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -314,6 +319,7 @@ test_that("A-A+B", {
 })
 
 test_that("A-B-A-B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -367,6 +373,7 @@ test_that("A-B-A-B", {
 })
 
 test_that("A-B-A", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -419,6 +426,7 @@ test_that("A-B-A", {
 })
 
 test_that("A-B-B, collapse to A-B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -471,6 +479,7 @@ test_that("A-B-B, collapse to A-B", {
 })
 
 test_that("A-B-B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -523,6 +532,7 @@ test_that("A-B-B", {
 })
 
 test_that("A+B-A", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -575,6 +585,7 @@ test_that("A+B-A", {
 })
 
 test_that("A-A-B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -627,6 +638,7 @@ test_that("A-A-B", {
 })
 
 test_that("A-A-B, collapse to A-B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -679,6 +691,7 @@ test_that("A-A-B, collapse to A-B", {
 })
 
 test_that("A+B-A+B, collapse to A+B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -732,6 +745,7 @@ test_that("A+B-A+B, collapse to A+B", {
 })
 
 test_that("A+B-A+B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -785,6 +799,7 @@ test_that("A+B-A+B", {
 })
 
 test_that("A-A+B-B", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -836,6 +851,7 @@ test_that("A-A+B-B", {
 })
 
 test_that("A-A-C-A+B+C-C", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -888,6 +904,7 @@ test_that("A-A-C-A+B+C-C", {
 })
 
 test_that("A-A+B+C-A+C-C", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -940,6 +957,7 @@ test_that("A-A+B+C-A+C-C", {
 })
 
 test_that("A-A+C-C-B+C-C", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -993,6 +1011,7 @@ test_that("A-A+C-C-B+C-C", {
 })
 
 test_that("start event == start target", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -1043,6 +1062,7 @@ test_that("start event == start target", {
 })
 
 test_that("end event == end target", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -1093,6 +1113,7 @@ test_that("end event == end target", {
 })
 
 test_that("start-end event == start-end target", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -1143,6 +1164,7 @@ test_that("start-end event == start-end target", {
 })
 
 test_that("start event < start target", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
 
   cohorts <- data.frame(
@@ -1184,6 +1206,7 @@ test_that("start event < start target", {
 })
 
 test_that("start event < start target, periodPrior = 60", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -1234,6 +1257,7 @@ test_that("start event < start target, periodPrior = 60", {
 })
 
 test_that("start event > end target", {
+  skip_if_not(ableToRun()$CDMC)
   con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
   
   cohorts <- data.frame(
@@ -1270,6 +1294,61 @@ test_that("start event > end target", {
   expect_message(
     TreatmentPatterns::export(andromeda, tempDir, minCellCount = 1),
     "Treatment History table is empty. Nothing to export.")
+  
+  DBI::dbDisconnect(con)
+})
+
+test_that("collapse A-B-B-B to A-A+B-B", {
+  skip_if_not(ableToRun()$CDMC)
+  con <- DBI::dbConnect(duckdb::duckdb(), dbdir = eunomia_dir())
+  
+  cohorts <- data.frame(
+    cohortId = c(1, 2, 3),
+    cohortName = c("X", "A", "B"),
+    type = c("target", "event", "event")
+  )
+  
+  cohort_table <- dplyr::tribble(
+    ~cohort_definition_id, ~subject_id, ~cohort_start_date,    ~cohort_end_date,
+    1,                     5,           as.Date("2014-01-01"), as.Date("2015-12-31"),
+    2,                     5,           as.Date("2014-05-20"), as.Date("2014-08-17"),
+    3,                     5,           as.Date("2014-07-08"), as.Date("2014-08-25"),
+    3,                     5,           as.Date("2014-10-19"), as.Date("2015-02-22"),
+    3,                     5,           as.Date("2015-02-28"), as.Date("2015-09-26")
+  )
+  
+  copy_to(con, cohort_table, overwrite = TRUE)
+  
+  cdm <- cdmFromCon(con, cdmSchema = "main", writeSchema = "main", cohortTables = "cohort_table")
+  
+  andromeda <- TreatmentPatterns::computePathways(
+    cohorts = cohorts,
+    cohortTableName = 'cohort_table',
+    cdm = cdm,
+    tempEmulationSchema = NULL,
+    includeTreatments = "startDate",
+    periodPriorToIndex = 0,
+    minEraDuration = 30,
+    eraCollapseSize = 30,
+    combinationWindow = 30,
+    minPostCombinationDuration = 30,
+    filterTreatments = "All",
+    maxPathLength = 5
+  )
+  
+  tempDir <- tempdir()
+  TreatmentPatterns::export(andromeda, tempDir, minCellCount = 1)
+  
+  treatmentPaths <- read.csv(file.path(tempDir, "treatmentPathways.csv"))
+  
+  path <- treatmentPaths %>%
+    dplyr::filter(
+      .data$age == "all",
+      .data$sex == "all",
+      .data$indexYear == "all") %>%
+    dplyr::pull(.data$path)
+  
+  expect_identical(path, "A-A+B-B")
   
   DBI::dbDisconnect(con)
 })


### PR DESCRIPTION
* Updated some tests to work with later versions of omopgenerics.
* Fixed issue with where combinations sometimes got miss-classified.
* Fixed issue when event starts and ends on end-date of target.
* Fixed issue when collapsing events when there is also a combination, when `filterTreatments = "All"`.
* Added check in tests to only run if packages are availible. (noSuggests, M1).