### PR TITLE
Added keep and truncate algo

### DIFF
--- a/R/computePathways.R
+++ b/R/computePathways.R
@@ -38,6 +38,10 @@
 #' @template param_maxPathLength
 #' @param analysisId (`character(1)`) Identifier for the TreatmentPatterns analysis.
 #' @param description (`character(1)`) Description of the analysis.
+#' @param overlapMethod (`character(1)`: `"truncate"`) Method to decide how to deal
+#' with overlap that is not significant enough for combination. `"keep"` will
+#' keep the dates as is. `"truncate"` truncates the first occurring event to
+#' the start date of the next event.
 #'
 #' @return (`Andromeda::andromeda()`)
 #' \link[Andromeda]{andromeda} object containing non-sharable patient level
@@ -122,7 +126,8 @@ computePathways <- function(
     combinationWindow = 30,
     minPostCombinationDuration = 30,
     filterTreatments = "First",
-    maxPathLength = 5) {
+    maxPathLength = 5,
+    overlapMethod = "truncate") {
   validateComputePathways()
 
   args <- eval(
@@ -388,7 +393,7 @@ validateComputePathways <- function() {
     add = assertCol,
     .var.name = "resultSchema"
   )
-  
+
   checkmate::assertClass(
     args$cdm,
     classes = "cdm_reference",
@@ -396,7 +401,13 @@ validateComputePathways <- function() {
     add = assertCol,
     .var.name = "cdm"
   )
-  
+
+  checkmate::assertChoice(
+    x = args$overlapMethod,
+    choices = c("truncate", "keep"),
+    null.ok = FALSE
+  )
+
   checkmate::reportAssertions(collection = assertCol)
 }
 

--- a/R/constructPathways.R
+++ b/R/constructPathways.R
@@ -83,7 +83,8 @@ constructPathways <- function(settings, andromeda) {
       doCombinationWindow(
         andromeda = andromeda,
         combinationWindow = settings$combinationWindow,
-        minPostCombinationDuration = settings$minPostCombinationDuration
+        minPostCombinationDuration = settings$minPostCombinationDuration,
+        overlapMethod = settings$overlapMethod
       )
   
       doFilterTreatments(
@@ -431,10 +432,12 @@ doEraCollapse <- function(andromeda, eraCollapseSize) {
 doCombinationWindow <- function(
     andromeda,
     combinationWindow,
-    minPostCombinationDuration) {
+    minPostCombinationDuration,
+    overlapMethod
+  ) {
   # Find which rows contain some overlap
-  selectRowsCombinationWindow(andromeda, combinationWindow)
-  
+  selectRowsCombinationWindow(andromeda, combinationWindow, overlapMethod)
+
   # While rows that need modification exist:
   iterations <- 1
   
@@ -525,12 +528,16 @@ doCombinationWindow <- function(
         eventCohortIdPrevious = dplyr::lag(
           .data$eventCohortId,
           order_by = .data$eventStartDate)) %>%
-      dplyr::ungroup() # %>%
-      # dplyr::mutate(
-      #   eventEndDate = dplyr::case_when(
-      #     dplyr::lead(.data$switch) == 1 ~ .data$eventStartDateNext,
-      #     .default = .data$eventEndDate))
-    
+      dplyr::ungroup()
+
+    if (overlapMethod == "truncate") {
+      andromeda$treatmentHistory <- andromeda$treatmentHistory %>%
+      dplyr::mutate(
+        eventEndDate = dplyr::case_when(
+          dplyr::lead(.data$switch) == 1 ~ .data$eventStartDateNext,
+          .default = .data$eventEndDate))
+    }
+
     andromeda[[sprintf("addRowsFRFS_%s", iterations)]] <- andromeda$treatmentHistory %>%
       dplyr::filter(.data$combinationFRFS == 1)
     
@@ -619,7 +626,7 @@ doCombinationWindow <- function(
         "sex", "eventEndDate", "durationEra", "gapPrevious"
       )
     
-    selectRowsCombinationWindow(andromeda, combinationWindow)
+    selectRowsCombinationWindow(andromeda, combinationWindow, overlapMethod)
     iterations <- iterations + 1
   }
   
@@ -649,7 +656,7 @@ doCombinationWindow <- function(
 #' @param andromeda (`Andromeda::andromeda()`)
 #'
 #' @return (`invisible(NULL)`)
-selectRowsCombinationWindow <- function(andromeda, combinationWindow) {
+selectRowsCombinationWindow <- function(andromeda, combinationWindow, overlapMethod) {
   # Order treatmentHistory by person_id, event_start_date, event_end_date
   # andromeda$treatmentHistory <- andromeda$treatmentHistory %>%
   #   arrange(.data$personId, .data$eventStartDate, .data$eventEndDate)
@@ -683,12 +690,24 @@ selectRowsCombinationWindow <- function(andromeda, combinationWindow) {
     dplyr::ungroup() %>%
     dplyr::select("allRows") %>%
     dplyr::pull()
-  
-  treatmentHistory <- andromeda$treatmentHistory %>%
-    dplyr::mutate(selectedRows = dplyr::case_when(
-      dplyr::row_number() %in% rows & -.data$gapPrevious >= combinationWindow ~ 1,
-      .default = 0
-    ))
+
+  if (overlapMethod == "truncate") {
+    treatmentHistory <- andromeda$treatmentHistory %>%
+      dplyr::mutate(
+        selectedRows = dplyr::case_when(
+          dplyr::row_number() %in% rows ~ 1,
+          .default = 0
+        )
+      )
+  } else if (overlapMethod == "keep") {
+    treatmentHistory <- andromeda$treatmentHistory %>%
+      dplyr::mutate(
+        selectedRows = dplyr::case_when(
+          dplyr::row_number() %in% rows & -.data$gapPrevious >= combinationWindow ~ 1,
+          .default = 0
+        )
+      )
+  }
   
   # treatmentHistory[, ALL_ROWS := NULL]
   andromeda$treatmentHistory <- treatmentHistory %>%

--- a/man/computePathways.Rd
+++ b/man/computePathways.Rd
@@ -23,7 +23,8 @@ computePathways(
   combinationWindow = 30,
   minPostCombinationDuration = 30,
   filterTreatments = "First",
-  maxPathLength = 5
+  maxPathLength = 5,
+  overlapMethod = "truncate"
 )
 }
 \arguments{
@@ -93,6 +94,11 @@ event cohorts (‘All’).}
 
 \item{maxPathLength}{(\code{integer(1)}: \code{5})\cr
 Maximum number of steps included in treatment pathway}
+
+\item{overlapMethod}{(\code{character(1)}: \code{"truncate"}) Method to decide how to deal
+with overlap that is not significant enough for combination. \code{"keep"} will
+keep the dates as is. \code{"truncate"} truncates the first occurring event to
+the start date of the next event.}
 }
 \value{
 (\code{Andromeda::andromeda()})

--- a/tests/testthat/test-pathwaysLogical.R
+++ b/tests/testthat/test-pathwaysLogical.R
@@ -1567,9 +1567,9 @@ test_that("A-A+B-B to A-B", {
   )
   
   copy_to(con, cohort_table, overwrite = TRUE)
-  
+
   cdm <- cdmFromCon(con, cdmSchema = "main", writeSchema = "main", cohortTables = "cohort_table")
-  
+
   andromeda <- TreatmentPatterns::computePathways(
     cohorts = cohorts,
     cohortTableName = "cohort_table",
@@ -1577,11 +1577,12 @@ test_that("A-A+B-B to A-B", {
     includeTreatments = "startDate",
     minEraDuration = 30,
     combinationWindow = 30,
-    minPostCombinationDuration = 30
+    minPostCombinationDuration = 30,
+    overlapMethod = "keep"
   )
-  
+
   result <- TreatmentPatterns::export(andromeda, minCellCount = 1)
-  
+
   expect_identical(result$treatment_pathways$pathway, "A-B")
 
   DBI::dbDisconnect(con)


### PR DESCRIPTION
Pick either `truncate` (default) or `keep` when dealing with not-significant overlap between treatments

```
A:          |-------------------------------------|
B:                                          |-------------------------|

            A start                    A end B start              B end
truncate:   |-------------------------------|-------------------------|


            A start                   B start     A end           B end
keep:       |-------------------------------|-----|-------------------|
```